### PR TITLE
Fixed include issue in NORA-B1 ns variants

### DIFF
--- a/zephyr/boards/arm/ubx_evknorab10_nrf5340/ubx_evknorab10_nrf5340_cpuapp_ns.dts
+++ b/zephyr/boards/arm/ubx_evknorab10_nrf5340/ubx_evknorab10_nrf5340_cpuapp_ns.dts
@@ -7,7 +7,7 @@
 
 /dts-v1/;
 #include <nordic/nrf5340_cpuappns_qkaa.dtsi>
-#include "ubx_evknorab10_cpuapp_common.dts"
+#include "ubx_evknorab10_cpuapp_common.dtsi"
 
 / {
 	model = "u-blox EVK-NORA-B10 NRF5340 Application";

--- a/zephyr/boards/arm/ubx_evknorab12_nrf5340/ubx_evknorab12_nrf5340_cpuapp_ns.dts
+++ b/zephyr/boards/arm/ubx_evknorab12_nrf5340/ubx_evknorab12_nrf5340_cpuapp_ns.dts
@@ -7,7 +7,7 @@
 
 /dts-v1/;
 #include <nordic/nrf5340_cpuappns_qkaa.dtsi>
-#include "ubx_evknorab12_cpuapp_common.dts"
+#include "ubx_evknorab12_cpuapp_common.dtsi"
 
 / {
 	model = "u-blox EVK-NORA-B12 NRF5340 Application";

--- a/zephyr/boards/arm/ubx_mininorab10_nrf5340/ubx_mininorab10_nrf5340_cpuapp_ns.dts
+++ b/zephyr/boards/arm/ubx_mininorab10_nrf5340/ubx_mininorab10_nrf5340_cpuapp_ns.dts
@@ -7,7 +7,7 @@
 
 /dts-v1/;
 #include <nordic/nrf5340_cpuappns_qkaa.dtsi>
-#include "ubx_mininorab10_cpuapp_common.dts"
+#include "ubx_mininorab10_cpuapp_common.dtsi"
 
 / {
 	model = "u-blox MINI-NORA-B10 NRF5340 Application";

--- a/zephyr/boards/arm/ubx_mininorab12_nrf5340/ubx_mininorab12_nrf5340_cpuapp_ns.dts
+++ b/zephyr/boards/arm/ubx_mininorab12_nrf5340/ubx_mininorab12_nrf5340_cpuapp_ns.dts
@@ -7,7 +7,7 @@
 
 /dts-v1/;
 #include <nordic/nrf5340_cpuappns_qkaa.dtsi>
-#include "ubx_mininorab12_cpuapp_common.dts"
+#include "ubx_mininorab12_cpuapp_common.dtsi"
 
 / {
 	model = "u-blox MINI-NORA-B12 NRF5340 Application";


### PR DESCRIPTION
The secure variants of NORA-B1 Zephyr configs did not build.

Closes #33 